### PR TITLE
feat: Friends Api Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Documentation can be found [here](https://docs.rs/roboat/).
     - Fetch Count of Pending Friend Requests - [`Client::pending_friend_requests`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.pending_friend_requests)
     - Fetch Friend Requests - [`Client::friend_requests`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.friend_requests)
     - Fetch Friends List - [`Client::friends_list`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.friends_list)
+    - Accept Friend Request - [`Client::accept_friend_request`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.accept_friend_request)
+    - Decline Friend Request - [`Client::decline_friend_request`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.decline_friend_request)
 * UNDER CONSTRUCTION
     - Upload Classic Clothing to Group - [`Client::upload_classic_clothing_to_group`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.upload_classic_clothing_to_group)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Documentation can be found [here](https://docs.rs/roboat/).
     - User Search - [`Client::user_search`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.user_search)
     - Username User Search - [`Client::username_user_search`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.username_user_search)
     - Fetch User Details - [`Client::user_details`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.user_details)
+* Friends API - [`friends.roblox.com/*`]
+    - Fetch Count of Pending Friend Requests - [`Client::pending_friend_requests`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.pending_friend_requests)
+    - Fetch Friend Requests - [`Client::friend_requests`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.friend_requests)
+    - Fetch Friends List - [`Client::friends_list`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.friends_list)
 * UNDER CONSTRUCTION
     - Upload Classic Clothing to Group - [`Client::upload_classic_clothing_to_group`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.upload_classic_clothing_to_group)
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Documentation can be found [here](https://docs.rs/roboat/).
     - Fetch Friends List - [`Client::friends_list`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.friends_list)
     - Accept Friend Request - [`Client::accept_friend_request`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.accept_friend_request)
     - Decline Friend Request - [`Client::decline_friend_request`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.decline_friend_request)
+    - Send Friend Request - [`Client::send_friend_request`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.send_friend_request)
+    - Unfriend - [`Client::unfriend`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.unfriend)
 * UNDER CONSTRUCTION
     - Upload Classic Clothing to Group - [`Client::upload_classic_clothing_to_group`](https://docs.rs/roboat/latest/roboat/struct.Client.html#method.upload_classic_clothing_to_group)
 

--- a/examples/friend_request_action.rs
+++ b/examples/friend_request_action.rs
@@ -3,9 +3,7 @@ use serde::Serialize;
 
 use roboat::ClientBuilder;
 
-#[derive(
-    clap::ValueEnum, Clone, Debug, Serialize,
-)]
+#[derive(clap::ValueEnum, Clone, Debug, Serialize)]
 enum FriendRequestAction {
     Accept,
     Decline,
@@ -41,8 +39,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     eprintln!(" {}", err)
                 }
             }
-
-        },
+        }
         FriendRequestAction::Decline => {
             match client.decline_friend_request(args.requester_id).await {
                 Ok(_) => {

--- a/examples/friend_request_action.rs
+++ b/examples/friend_request_action.rs
@@ -1,0 +1,60 @@
+use clap::Parser;
+use serde::Serialize;
+
+use roboat::ClientBuilder;
+
+#[derive(
+    clap::ValueEnum, Clone, Debug, Serialize,
+)]
+enum FriendRequestAction {
+    Accept,
+    Decline,
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    roblosecurity: String,
+
+    #[arg(long, short)]
+    requester_id: u64,
+
+    #[arg(long, short)]
+    action: FriendRequestAction,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let client = ClientBuilder::new()
+        .roblosecurity(args.roblosecurity)
+        .build();
+
+    match args.action {
+        FriendRequestAction::Accept => {
+            match client.accept_friend_request(args.requester_id).await {
+                Ok(_) => {
+                    println!("Accepted!")
+                }
+                Err(err) => {
+                    eprintln!("Error while accepting!");
+                    eprintln!(" {}", err)
+                }
+            }
+
+        },
+        FriendRequestAction::Decline => {
+            match client.decline_friend_request(args.requester_id).await {
+                Ok(_) => {
+                    println!("Declined!")
+                }
+                Err(err) => {
+                    eprintln!("Error while declining!");
+                    eprintln!(" {}", err)
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/friend_requests.rs
+++ b/examples/friend_requests.rs
@@ -14,7 +14,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .roblosecurity(args.roblosecurity)
         .build();
 
-
     let pending_friend_requests = client.pending_friend_requests().await?;
 
     println!("Found {} pending requests.", pending_friend_requests);
@@ -27,7 +26,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (friend_requests, next_cursor) = client.friend_requests(current_cursor).await?;
 
         for user in friend_requests {
-            println!(" - {} from {}: {}", user.username, user.origin_source_type,  user.user_id);
+            println!(
+                " - {} from {}: {}",
+                user.username, user.origin_source_type, user.user_id
+            );
         }
 
         if let Some(cursor) = next_cursor {

--- a/examples/friend_requests.rs
+++ b/examples/friend_requests.rs
@@ -22,11 +22,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // iterate through all friend requests
 
     let mut current_cursor = None;
+
     loop {
         let (friend_requests, next_cursor) = client.friend_requests(current_cursor).await?;
 
         for user in friend_requests {
-            println!(" - {} from {}: {}", user.username, user.friend_request.origin_source_type,  user.user_id);
+            println!(" - {} from {}: {}", user.username, user.origin_source_type,  user.user_id);
         }
 
         if let Some(cursor) = next_cursor {

--- a/examples/friend_requests.rs
+++ b/examples/friend_requests.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (friend_requests, next_cursor) = client.friend_requests(current_cursor).await?;
 
         for user in friend_requests {
-            println!(" - {}: {}", user.username, user.user_id);
+            println!(" - {} from {}: {}", user.username, user.friend_request.origin_source_type,  user.user_id);
         }
 
         if let Some(cursor) = next_cursor {

--- a/examples/friend_requests.rs
+++ b/examples/friend_requests.rs
@@ -1,0 +1,40 @@
+use clap::Parser;
+use roboat::ClientBuilder;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, short)]
+    roblosecurity: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let client = ClientBuilder::new()
+        .roblosecurity(args.roblosecurity)
+        .build();
+
+
+    let pending_friend_requests = client.pending_friend_requests().await?;
+
+    println!("Found {} pending requests.", pending_friend_requests);
+
+    // iterate through all friend requests
+
+    let mut current_cursor = None;
+    loop {
+        let (friend_requests, next_cursor) = client.friend_requests(current_cursor).await?;
+
+        for user in friend_requests {
+            println!(" - {}: {}", user.username, user.user_id);
+        }
+
+        if let Some(cursor) = next_cursor {
+            current_cursor = Some(cursor)
+        } else {
+            break;
+        }
+    }
+
+    Ok(())
+}

--- a/examples/friends_list.rs
+++ b/examples/friends_list.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
-use roboat::ClientBuilder;
 use roboat::presence::PresenceType;
+use roboat::ClientBuilder;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -12,8 +12,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    let client = ClientBuilder::new()
-        .build();
+    let client = ClientBuilder::new().build();
 
     let friends = client.friends_list(args.user_id).await?;
 

--- a/examples/friends_list.rs
+++ b/examples/friends_list.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use roboat::ClientBuilder;
+use roboat::friends::PresenceType;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -17,7 +18,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Found {} friends.", friends.len());
     for friend in friends {
-        println!("{}: {}", friend.username, friend.user_id);
+        print!("{}: {} ", friend.username, friend.user_id);
+        if friend.presence_type != PresenceType::Offline {
+            println!("({:?})", friend.presence_type)
+        } else {
+            println!();
+        }
     }
 
     Ok(())

--- a/examples/friends_list.rs
+++ b/examples/friends_list.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
+
 use roboat::ClientBuilder;
-use roboat::friends::PresenceType;
+use roboat::presence::PresenceType;
 
 #[derive(Parser, Debug)]
 struct Args {

--- a/examples/friends_list.rs
+++ b/examples/friends_list.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use roboat::ClientBuilder;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, short)]
+    user_id: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let client = ClientBuilder::new()
+        .build();
+
+    let friends = client.friends_list(args.user_id).await?;
+
+    println!("Found {} friends.", friends.len());
+    for friend in friends {
+        println!("{}: {}", friend.username, friend.user_id);
+    }
+
+    Ok(())
+}

--- a/examples/send_friend_request.rs
+++ b/examples/send_friend_request.rs
@@ -1,0 +1,31 @@
+use clap::Parser;
+use roboat::ClientBuilder;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, short)]
+    roblosecurity: String,
+
+    #[arg(long, short)]
+    target_id: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let client = ClientBuilder::new()
+        .roblosecurity(args.roblosecurity)
+        .build();
+
+    match client.send_friend_request(args.target_id).await {
+        Ok(_) => {
+            println!("Sent!")
+        }
+        Err(err) => {
+            eprintln!("Error while sending!");
+            eprintln!(" {}", err)
+        }
+    }
+
+    Ok(())
+}

--- a/examples/unfriend.rs
+++ b/examples/unfriend.rs
@@ -1,0 +1,31 @@
+use clap::Parser;
+use roboat::ClientBuilder;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long, short)]
+    roblosecurity: String,
+
+    #[arg(long, short)]
+    target_id: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let client = ClientBuilder::new()
+        .roblosecurity(args.roblosecurity)
+        .build();
+
+    match client.unfriend(args.target_id).await {
+        Ok(_) => {
+            println!("Unfriended!")
+        }
+        Err(err) => {
+            eprintln!("Error while unfriending!");
+            eprintln!(" {}", err)
+        }
+    }
+
+    Ok(())
+}

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -6,7 +6,7 @@ use crate::presence::PresenceType;
 
 mod request_types;
 
-const FRIENDS_LIST_API: &str = "https://friends.roblox.com/v1/users/{user_id}/friends?userSort=StatusFrequents";
+const FRIENDS_LIST_API: &str = "https://friends.roblox.com/v1/users/{user_id}/friends";
 const FRIEND_REQUESTS_API: &str = "https://friends.roblox.com/v1/my/friends/requests";
 const PENDING_FRIEND_REQUESTS_API: &str = "https://friends.roblox.com/v1/user/friend-requests/count";
 
@@ -486,6 +486,7 @@ impl Client {
 mod internal {
     use reqwest::header;
     use serde_json::json;
+
     use crate::{Client, RoboatError, XCSRF_HEADER};
 
     impl Client {

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -1,19 +1,23 @@
 use reqwest::header;
 use serde::{Deserialize, Serialize};
 
-use crate::{Client, RoboatError};
 use crate::presence::PresenceType;
+use crate::{Client, RoboatError};
 
 mod request_types;
 
 const FRIENDS_LIST_API: &str = "https://friends.roblox.com/v1/users/{user_id}/friends";
 const FRIEND_REQUESTS_API: &str = "https://friends.roblox.com/v1/my/friends/requests";
-const PENDING_FRIEND_REQUESTS_API: &str = "https://friends.roblox.com/v1/user/friend-requests/count";
+const PENDING_FRIEND_REQUESTS_API: &str =
+    "https://friends.roblox.com/v1/user/friend-requests/count";
 
-const ACCEPT_FRIEND_REQUEST_API: &str = "https://friends.roblox.com/v1/users/{requester_id}/accept-friend-request";
-const DECLINE_FRIEND_REQUEST_API: &str = "https://friends.roblox.com/v1/users/{requester_id}/decline-friend-request";
+const ACCEPT_FRIEND_REQUEST_API: &str =
+    "https://friends.roblox.com/v1/users/{requester_id}/accept-friend-request";
+const DECLINE_FRIEND_REQUEST_API: &str =
+    "https://friends.roblox.com/v1/users/{requester_id}/decline-friend-request";
 
-const SEND_FRIEND_REQUEST_API: &str = "https://friends.roblox.com/v1/users/{target_id}/request-friendship";
+const SEND_FRIEND_REQUEST_API: &str =
+    "https://friends.roblox.com/v1/users/{target_id}/request-friendship";
 const UNFRIEND_API: &str = "https://friends.roblox.com/v1/users/{target_id}/unfriend";
 
 /// Model, representing user information that also contains select presence information
@@ -81,7 +85,6 @@ pub struct FriendRequest {
     pub sent_at: String,
 }
 
-
 impl Client {
     /// Get list of all friends for the specified user using <https://friends.roblox.com/v1/users/{userId}/friends>.
     ///
@@ -114,14 +117,13 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn friends_list(&self, user_id: u64) -> Result<Vec<FriendUserInformation>, RoboatError> {
+    pub async fn friends_list(
+        &self,
+        user_id: u64,
+    ) -> Result<Vec<FriendUserInformation>, RoboatError> {
         let formatted_url = FRIENDS_LIST_API.replace("{user_id}", &user_id.to_string());
 
-        let request_result = self
-            .reqwest_client
-            .get(formatted_url)
-            .send()
-            .await;
+        let request_result = self.reqwest_client.get(formatted_url).send().await;
 
         let response = Self::validate_request_result(request_result).await?;
 
@@ -252,9 +254,7 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn pending_friend_requests(
-        &self,
-    ) -> Result<u64, RoboatError> {
+    pub async fn pending_friend_requests(&self) -> Result<u64, RoboatError> {
         let cookie = self.cookie_string()?;
         let formatted_url = PENDING_FRIEND_REQUESTS_API;
 
@@ -267,7 +267,8 @@ impl Client {
 
         let response = Self::validate_request_result(request_result).await?;
 
-        let raw = Self::parse_to_raw::<request_types::PendingFriendRequestsResponse>(response).await?;
+        let raw =
+            Self::parse_to_raw::<request_types::PendingFriendRequestsResponse>(response).await?;
 
         Ok(raw.count)
     }
@@ -301,24 +302,14 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn accept_friend_request(
-        &self,
-        requester_id: u64,
-    ) -> Result<(), RoboatError> {
-        match self
-            .accept_friend_request_internal(
-                requester_id,
-            )
-            .await
-        {
+    pub async fn accept_friend_request(&self, requester_id: u64) -> Result<(), RoboatError> {
+        match self.accept_friend_request_internal(requester_id).await {
             Ok(x) => Ok(x),
             Err(e) => match e {
                 RoboatError::InvalidXcsrf(new_xcsrf) => {
                     self.set_xcsrf(new_xcsrf).await;
 
-                    self.accept_friend_request_internal(
-                        requester_id,
-                    ).await
+                    self.accept_friend_request_internal(requester_id).await
                 }
                 _ => Err(e),
             },
@@ -354,24 +345,14 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn decline_friend_request(
-        &self,
-        requester_id: u64,
-    ) -> Result<(), RoboatError> {
-        match self
-            .decline_friend_request_internal(
-                requester_id,
-            )
-            .await
-        {
+    pub async fn decline_friend_request(&self, requester_id: u64) -> Result<(), RoboatError> {
+        match self.decline_friend_request_internal(requester_id).await {
             Ok(x) => Ok(x),
             Err(e) => match e {
                 RoboatError::InvalidXcsrf(new_xcsrf) => {
                     self.set_xcsrf(new_xcsrf).await;
 
-                    self.decline_friend_request_internal(
-                        requester_id
-                    ).await
+                    self.decline_friend_request_internal(requester_id).await
                 }
                 _ => Err(e),
             },
@@ -406,24 +387,14 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn send_friend_request(
-        &self,
-        target_id: u64,
-    ) -> Result<(), RoboatError> {
-        match self
-            .send_friend_request_internal(
-                target_id,
-            )
-            .await
-        {
+    pub async fn send_friend_request(&self, target_id: u64) -> Result<(), RoboatError> {
+        match self.send_friend_request_internal(target_id).await {
             Ok(_) => Ok(()),
             Err(e) => match e {
                 RoboatError::InvalidXcsrf(new_xcsrf) => {
                     self.set_xcsrf(new_xcsrf).await;
 
-                    self.send_friend_request_internal(
-                        target_id
-                    ).await
+                    self.send_friend_request_internal(target_id).await
                 }
                 _ => Err(e),
             },
@@ -458,24 +429,14 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn unfriend(
-        &self,
-        target_id: u64,
-    ) -> Result<(), RoboatError> {
-        match self
-            .unfriend_internal(
-                target_id,
-            )
-            .await
-        {
+    pub async fn unfriend(&self, target_id: u64) -> Result<(), RoboatError> {
+        match self.unfriend_internal(target_id).await {
             Ok(_) => Ok(()),
             Err(e) => match e {
                 RoboatError::InvalidXcsrf(new_xcsrf) => {
                     self.set_xcsrf(new_xcsrf).await;
 
-                    self.unfriend_internal(
-                        target_id
-                    ).await
+                    self.unfriend_internal(target_id).await
                 }
                 _ => Err(e),
             },
@@ -544,8 +505,8 @@ mod internal {
             &self,
             target_id: u64,
         ) -> Result<(), RoboatError> {
-            let formatted_url = super::SEND_FRIEND_REQUEST_API
-                .replace("{target_id}", &target_id.to_string());
+            let formatted_url =
+                super::SEND_FRIEND_REQUEST_API.replace("{target_id}", &target_id.to_string());
 
             let cookie = self.cookie_string()?;
             let xcsrf = self.xcsrf().await;
@@ -571,12 +532,8 @@ mod internal {
             Ok(())
         }
 
-        pub(super) async fn unfriend_internal(
-            &self,
-            target_id: u64,
-        ) -> Result<(), RoboatError> {
-            let formatted_url = super::UNFRIEND_API
-                .replace("{target_id}", &target_id.to_string());
+        pub(super) async fn unfriend_internal(&self, target_id: u64) -> Result<(), RoboatError> {
+            let formatted_url = super::UNFRIEND_API.replace("{target_id}", &target_id.to_string());
 
             let cookie = self.cookie_string()?;
             let xcsrf = self.xcsrf().await;

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -6,15 +6,15 @@ use crate::presence::PresenceType;
 
 mod request_types;
 
-const FRIENDS_LIST: &str = "https://friends.roblox.com/v1/users/{user_id}/friends";
-const FRIEND_REQUESTS: &str = "https://friends.roblox.com/v1/my/friends/requests";
-const PENDING_FRIEND_REQUESTS: &str = "https://friends.roblox.com/v1/user/friend-requests/count";
+const FRIENDS_LIST_API: &str = "https://friends.roblox.com/v1/users/{user_id}/friends?userSort=StatusFrequents";
+const FRIEND_REQUESTS_API: &str = "https://friends.roblox.com/v1/my/friends/requests";
+const PENDING_FRIEND_REQUESTS_API: &str = "https://friends.roblox.com/v1/user/friend-requests/count";
 
-const ACCEPT_FRIEND_REQUEST: &str = "https://friends.roblox.com/v1/users/{requester_id}/accept-friend-request";
-const DECLINE_FRIEND_REQUEST: &str = "https://friends.roblox.com/v1/users/{requester_id}/decline-friend-request";
+const ACCEPT_FRIEND_REQUEST_API: &str = "https://friends.roblox.com/v1/users/{requester_id}/accept-friend-request";
+const DECLINE_FRIEND_REQUEST_API: &str = "https://friends.roblox.com/v1/users/{requester_id}/decline-friend-request";
 
-const SEND_FRIEND_REQUEST: &str = "https://friends.roblox.com/v1/users/{target_id}/request-friendship";
-const UNFRIEND: &str = "https://friends.roblox.com/v1/users/{target_id}/unfriend";
+const SEND_FRIEND_REQUEST_API: &str = "https://friends.roblox.com/v1/users/{target_id}/request-friendship";
+const UNFRIEND_API: &str = "https://friends.roblox.com/v1/users/{target_id}/unfriend";
 
 /// Model, representing user information that also contains select presence information
 #[allow(missing_docs)]
@@ -115,7 +115,7 @@ impl Client {
     /// # }
     /// ```
     pub async fn friends_list(&self, user_id: u64) -> Result<Vec<FriendUserInformation>, RoboatError> {
-        let formatted_url = FRIENDS_LIST.replace("{user_id}", &user_id.to_string());
+        let formatted_url = FRIENDS_LIST_API.replace("{user_id}", &user_id.to_string());
 
         let request_result = self
             .reqwest_client
@@ -185,7 +185,7 @@ impl Client {
         cursor: Option<String>,
     ) -> Result<(Vec<FriendRequest>, Option<String>), RoboatError> {
         let cookie = self.cookie_string()?;
-        let mut formatted_url = format!("{}?limit={}", FRIEND_REQUESTS, 10);
+        let mut formatted_url = format!("{}?limit={}", FRIEND_REQUESTS_API, 10);
 
         if let Some(cursor) = cursor {
             formatted_url = format!("{}&cursor={}", formatted_url, cursor)
@@ -256,7 +256,7 @@ impl Client {
         &self,
     ) -> Result<u64, RoboatError> {
         let cookie = self.cookie_string()?;
-        let formatted_url = PENDING_FRIEND_REQUESTS;
+        let formatted_url = PENDING_FRIEND_REQUESTS_API;
 
         let request_result = self
             .reqwest_client
@@ -493,7 +493,7 @@ mod internal {
             &self,
             requester_id: u64,
         ) -> Result<(), RoboatError> {
-            let formatted_url = super::ACCEPT_FRIEND_REQUEST
+            let formatted_url = super::ACCEPT_FRIEND_REQUEST_API
                 .replace("{requester_id}", &requester_id.to_string());
 
             let cookie = self.cookie_string()?;
@@ -518,7 +518,7 @@ mod internal {
             &self,
             requester_id: u64,
         ) -> Result<(), RoboatError> {
-            let formatted_url = super::DECLINE_FRIEND_REQUEST
+            let formatted_url = super::DECLINE_FRIEND_REQUEST_API
                 .replace("{requester_id}", &requester_id.to_string());
 
             let cookie = self.cookie_string()?;
@@ -543,7 +543,7 @@ mod internal {
             &self,
             target_id: u64,
         ) -> Result<(), RoboatError> {
-            let formatted_url = super::SEND_FRIEND_REQUEST
+            let formatted_url = super::SEND_FRIEND_REQUEST_API
                 .replace("{target_id}", &target_id.to_string());
 
             let cookie = self.cookie_string()?;
@@ -574,7 +574,7 @@ mod internal {
             &self,
             target_id: u64,
         ) -> Result<(), RoboatError> {
-            let formatted_url = super::UNFRIEND
+            let formatted_url = super::UNFRIEND_API
                 .replace("{target_id}", &target_id.to_string());
 
             let cookie = self.cookie_string()?;

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -98,24 +98,24 @@ pub struct FriendRequestUserInformation {
 pub struct FriendRequest {
     /// When the friend request was sent.
     #[serde(alias = "senderId")]
-    sender_id: u64,
+    pub sender_id: u64,
 
     /// The sender user Id.
     #[serde(alias = "sourceUniverseId")]
-    source_universe_id: u64,
+    pub source_universe_id: u64,
 
     /// The source universe Id which the request was sent in.
     #[serde(alias = "sentAt")]
-    sent_at: String,
+    pub sent_at: String,
 
     /// The origin source type associated with the friend request.
     /// ['Unknown' = 0, 'PlayerSearch' = 1, 'QrCode' = 2, 'InGame' = 3, 'UserProfile' = 4, 'QqContactImporter' = 5, 'WeChatContactImporter' = 6, 'ProfileShare' = 7, 'PhoneContactImporter' = 8, 'FriendRecommendations' = 9]
     #[serde(alias = "originSourceType")]
-    origin_source_type: String,
+    pub origin_source_type: String,
 
     /// The contact name associated with the friend request.
     #[serde(alias = "contactName")]
-    contact_name: Option<String>,
+    pub contact_name: Option<String>,
 }
 
 impl Client {

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -2,40 +2,13 @@ use reqwest::header;
 use serde::{Deserialize, Serialize};
 
 use crate::{Client, RoboatError};
+use crate::presence::PresenceType;
 
 mod request_types;
 
 const FRIENDS_LIST: &str = "https://friends.roblox.com/v1/users/{user_id}/friends";
 const FRIEND_REQUESTS: &str = "https://friends.roblox.com/v1/my/friends/requests";
 const PENDING_FRIEND_REQUESTS: &str = "https://friends.roblox.com/v1/user/friend-requests/count";
-
-// TODO: take out this enum to presence
-/// Presence of user
-#[allow(missing_docs)]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
-pub enum PresenceType {
-    #[default]
-    Offline,
-    Online,
-    InGame,
-    InStudio,
-    Invisible,
-}
-
-impl TryFrom<i32> for PresenceType {
-    type Error = RoboatError;
-
-    fn try_from(v: i32) -> Result<Self, Self::Error> {
-        match v {
-            0 => Ok(Self::Offline),
-            1 => Ok(Self::Online),
-            2 => Ok(Self::InGame),
-            3 => Ok(Self::InStudio),
-            4 => Ok(Self::Invisible),
-            _ => Err(RoboatError::MalformedResponse)
-        }
-    }
-}
 
 /// Model, representing user information that also contains select presence information
 #[allow(missing_docs)]

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -1,0 +1,228 @@
+use reqwest::header::{self, HeaderName, HeaderValue};
+use serde::{Deserialize, Serialize};
+
+use crate::{Client, RoboatError, User};
+
+mod request_types;
+
+const FRIENDS_LIST: &str = "https://friends.roblox.com/v1/users/{user_id}/friends";
+const FRIEND_REQUESTS: &str = "https://friends.roblox.com/v1/my/friends/requests";
+const PENDING_FRIEND_REQUESTS: &str = "https://friends.roblox.com/v1/user/friend-requests/count";
+
+/// Model, representing user information that also contains select presence information
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+pub struct FriendsUserInformation {
+    #[serde(alias = "id")]
+    pub user_id: u64,
+
+    #[serde(alias = "externalAppDisplayName")]
+    pub external_app_display_name: Option<String>,
+
+    #[serde(alias = "name")]
+    pub username: String,
+
+    #[serde(alias = "displayName")]
+    pub display_name: String,
+
+    /// Whether the user is online.
+    #[serde(alias = "isOnline")]
+    pub is_online: bool,
+
+    // TODO: make enum from it
+    /// Where the user is online. ['Offline' = 0, 'Online' = 1, 'InGame' = 2, 'InStudio' = 3, 'Invisible' = 4]
+    ///
+    /// Notes:
+    ///  * `None`, when user isn't online
+    #[serde(alias = "presenceType")]
+    pub presence_type: Option<i32>,
+
+    /// Whether the user is deleted.
+    #[serde(alias = "isDeleted")]
+    pub is_deleted: bool,
+
+    #[serde(alias = "isBanned")]
+    pub is_banned: bool,
+
+    /// Frequents value for the user.
+    #[serde(alias = "friendFrequentScore")]
+    pub friend_frequent_score: i64,
+
+    /// Frequents rank for the user.
+    #[serde(alias = "friendFrequentRank")]
+    pub friend_frequent_rank: i64,
+
+    /// The user's verified badge status.
+    #[serde(alias = "hasVerifiedBadge")]
+    pub has_verified_badge: bool,
+
+    pub description: Option<String>,
+    pub created: String,
+}
+
+/// Model, representing a friend request.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+pub struct FriendRequestUserInformation {
+    #[serde(alias = "friendRequest")]
+    pub friend_request: FriendRequest,
+
+    #[serde(alias = "mutualFriendsList")]
+    pub mutual_friends_list: Vec<String>,
+
+    #[serde(alias = "hasVerifiedBadge")]
+    pub has_verified_badge: bool,
+
+    pub description: Option<String>,
+
+    pub created: String,
+
+    #[serde(alias = "isBanned")]
+    pub is_banned: bool,
+
+    #[serde(alias = "externalAppDisplayName")]
+    pub external_app_display_name: Option<String>,
+
+    #[serde(alias = "id")]
+    pub user_id: u64,
+
+    #[serde(alias = "name")]
+    pub username: String,
+
+    #[serde(alias = "displayName")]
+    pub display_name: String
+}
+
+/// Model, representing a friend request.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+pub struct FriendRequest {
+    /// When the friend request was sent.
+    #[serde(alias = "senderId")]
+    sender_id: u64,
+
+    /// The sender user Id.
+    #[serde(alias = "sourceUniverseId")]
+    source_universe_id: u64,
+
+    /// The source universe Id which the request was sent in.
+    #[serde(alias = "sentAt")]
+    sent_at: String,
+
+    /// The origin source type associated with the friend request.
+    /// ['Unknown' = 0, 'PlayerSearch' = 1, 'QrCode' = 2, 'InGame' = 3, 'UserProfile' = 4, 'QqContactImporter' = 5, 'WeChatContactImporter' = 6, 'ProfileShare' = 7, 'PhoneContactImporter' = 8, 'FriendRecommendations' = 9]
+    #[serde(alias = "originSourceType")]
+    origin_source_type: String,
+
+    /// The contact name associated with the friend request.
+    #[serde(alias = "contactName")]
+    contact_name: Option<String>,
+}
+
+impl Client {
+    /// Get list of all friends for the specified user using <https://friends.roblox.com/v1/users/{userId}/friends>.
+    ///
+    /// # Notes
+    /// * Does not require a valid roblosecurity.
+    ///
+    /// # Errors
+    /// * All errors under [Standard Errors](#standard-errors).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use roboat::ClientBuilder;
+    ///
+    /// const ROBLOSECURITY: &str = "roblosecurity";
+    /// const KEYWORD: &str = "linkmon";
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = ClientBuilder::new().roblosecurity(ROBLOSECURITY.to_string()).build();
+    ///
+    /// let keyword = KEYWORD.to_string();
+    /// let users = client.friends_list(keyword).await?;
+    ///
+    /// println!("Found {} friends.", users.len());
+    ///
+    /// for user in users {
+    ///     println!("{}: {}", user.username, user.user_id);
+    /// }
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn friends_list(&self, user_id: u64) -> Result<Vec<FriendsUserInformation>, RoboatError> {
+        let formatted_url = FRIENDS_LIST.replace("{user_id}", &user_id.to_string());
+
+        let request_result = self
+            .reqwest_client
+            .get(formatted_url)
+            .send()
+            .await;
+
+        let response = Self::validate_request_result(request_result).await?;
+
+        let raw = Self::parse_to_raw::<request_types::FriendsListResponse>(response).await?;
+        Ok(raw.data)
+    }
+
+    // TODO: add cursor argument or get all requests at one
+    /// Get list of friend requests using <https://friends.roblox.com/v1/my/friends/requests>.
+    ///
+    /// # Notes
+    /// * Requires a valid roblosecurity.
+    ///
+    /// # Errors
+    /// * All errors under [Standard Errors](#standard-errors).
+    /// * All errors under [Auth Required Errors](#auth-required-errors).
+    ///
+    pub async fn friend_requests(
+        &self,
+        cursor: Option<String>,
+    ) -> Result<(Vec<FriendRequestUserInformation>, Option<String>), RoboatError> {
+        let cookie = self.cookie_string()?;
+        let formatted_url = format!("{}?limit={}", FRIEND_REQUESTS, 10);
+
+        let request_result = self
+            .reqwest_client
+            .get(formatted_url)
+            .header(header::COOKIE, cookie)
+            .send()
+            .await;
+
+        let response = Self::validate_request_result(request_result).await?;
+
+        let raw = Self::parse_to_raw::<request_types::FriendRequestsResponse>(response).await?;
+        Ok((raw.data, raw.next_page_cursor))
+    }
+
+    /// Get count of pending friend requests using <https://friends.roblox.com/v1/user/friend-requests/count>.
+    ///
+    /// # Notes
+    /// * Requires a valid roblosecurity.
+    ///
+    /// # Errors
+    /// * All errors under [Standard Errors](#standard-errors).
+    /// * All errors under [Auth Required Errors](#auth-required-errors).
+    ///
+    pub async fn pending_friend_requests(
+        &self,
+    ) -> Result<u64, RoboatError> {
+        let cookie = self.cookie_string()?;
+        let formatted_url = PENDING_FRIEND_REQUESTS;
+
+        let request_result = self
+            .reqwest_client
+            .get(formatted_url)
+            .header(header::COOKIE, cookie)
+            .send()
+            .await;
+
+        let response = Self::validate_request_result(request_result).await?;
+
+        let raw = Self::parse_to_raw::<request_types::PendingFriendRequestsResponse>(response).await?;
+
+        Ok(raw.count)
+    }
+}

--- a/src/friends/mod.rs
+++ b/src/friends/mod.rs
@@ -1,7 +1,6 @@
-use reqwest::header::{self, HeaderName, HeaderValue};
+use crate::{Client, RoboatError};
 use serde::{Deserialize, Serialize};
-
-use crate::{Client, RoboatError, User};
+use reqwest::header;
 
 mod request_types;
 
@@ -90,7 +89,7 @@ pub struct FriendRequestUserInformation {
     pub username: String,
 
     #[serde(alias = "displayName")]
-    pub display_name: String
+    pub display_name: String,
 }
 
 /// Model, representing a friend request.
@@ -134,19 +133,18 @@ impl Client {
     /// use roboat::ClientBuilder;
     ///
     /// const ROBLOSECURITY: &str = "roblosecurity";
-    /// const KEYWORD: &str = "linkmon";
+    /// const USER_ID: u64 = 1692828498;
     ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = ClientBuilder::new().roblosecurity(ROBLOSECURITY.to_string()).build();
     ///
-    /// let keyword = KEYWORD.to_string();
-    /// let users = client.friends_list(keyword).await?;
+    /// let friends = client.friends_list(USER_ID).await?;
     ///
-    /// println!("Found {} friends.", users.len());
+    /// println!("Found {} friends.", friends.len());
     ///
-    /// for user in users {
-    ///     println!("{}: {}", user.username, user.user_id);
+    /// for friend in friends {
+    ///     println!("{}: {}", friend.username, friend.user_id);
     /// }
     ///
     /// # Ok(())
@@ -168,7 +166,7 @@ impl Client {
     }
 
     // TODO: add cursor argument or get all requests at one
-    /// Get list of friend requests using <https://friends.roblox.com/v1/my/friends/requests>.
+    /// Get list of friend requests with cursor using <https://friends.roblox.com/v1/my/friends/requests>.
     ///
     /// # Notes
     /// * Requires a valid roblosecurity.
@@ -177,6 +175,26 @@ impl Client {
     /// * All errors under [Standard Errors](#standard-errors).
     /// * All errors under [Auth Required Errors](#auth-required-errors).
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use roboat::ClientBuilder;
+    ///
+    /// const ROBLOSECURITY: &str = "roblosecurity";
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = ClientBuilder::new().roblosecurity(ROBLOSECURITY.to_string()).build();
+    ///
+    /// let (friend_requests, next_cursor) = client.friend_requests(None).await?;
+    ///
+    /// for user in friend_requests {
+    ///     println!("{} from {}: {}", user.username, user.friend_request.origin_source_type,  user.user_id);
+    /// }
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn friend_requests(
         &self,
         cursor: Option<String>,
@@ -206,6 +224,24 @@ impl Client {
     /// * All errors under [Standard Errors](#standard-errors).
     /// * All errors under [Auth Required Errors](#auth-required-errors).
     ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use roboat::ClientBuilder;
+    ///
+    /// const ROBLOSECURITY: &str = "roblosecurity";
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = ClientBuilder::new().roblosecurity(ROBLOSECURITY.to_string()).build();
+    ///
+    /// let count_of_friend_requests = client.pending_friend_requests().await?;
+    ///
+    /// println!("There's a {} pending friend requests!", count_of_friend_requests);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn pending_friend_requests(
         &self,
     ) -> Result<u64, RoboatError> {

--- a/src/friends/request_types.rs
+++ b/src/friends/request_types.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-
 /// Model, representing user information that also contains select presence information
 #[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
@@ -24,7 +23,7 @@ pub struct FriendUserInformationRaw {
     pub friend_frequent_score: i64,
     pub friend_frequent_rank: i64,
 
-    pub has_verified_badge: bool
+    pub has_verified_badge: bool,
 }
 
 /// Model, representing a friend request.

--- a/src/friends/request_types.rs
+++ b/src/friends/request_types.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+use super::{FriendRequestUserInformation, FriendsUserInformation};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct FriendsListResponse {
+    pub data: Vec<FriendsUserInformation>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct FriendRequestsResponse {
+    pub previous_page_cursor: Option<String>,
+    pub next_page_cursor: Option<String>,
+
+    pub data: Vec<FriendRequestUserInformation>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct PendingFriendRequestsResponse {
+    pub count: u64,
+}

--- a/src/friends/request_types.rs
+++ b/src/friends/request_types.rs
@@ -1,10 +1,88 @@
 use serde::{Deserialize, Serialize};
-use super::{FriendRequestUserInformation, FriendsUserInformation};
+
+
+/// Model, representing user information that also contains select presence information
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FriendUserInformationRaw {
+    #[serde(alias = "id")]
+    pub id: u64,
+    #[serde(alias = "name")]
+    pub username: String,
+    pub display_name: String,
+    pub external_app_display_name: Option<String>,
+
+    pub description: Option<String>,
+    pub created: String,
+
+    pub is_online: bool,
+    pub is_deleted: bool,
+    pub is_banned: bool,
+    pub presence_type: Option<i32>,
+
+    pub friend_frequent_score: i64,
+    pub friend_frequent_rank: i64,
+
+    pub has_verified_badge: bool
+}
+
+/// Model, representing a friend request.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FriendRequestRaw {
+    #[serde(alias = "id")]
+    pub user_id: u64,
+
+    #[serde(alias = "name")]
+    pub username: String,
+
+    pub display_name: String,
+
+    pub external_app_display_name: Option<String>,
+
+    pub has_verified_badge: bool,
+
+    pub description: Option<String>,
+
+    pub created: String,
+
+    /// Whether the user is banned/terminated.
+    #[serde(alias = "isBanned")]
+    pub is_terminated: bool,
+
+    pub mutual_friends_list: Vec<String>,
+
+    pub friend_request: FriendRequestDetailsRaw,
+}
+
+/// Model, representing a friend request details.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FriendRequestDetailsRaw {
+    /// The sender user Id.
+    pub sender_id: u64,
+
+    /// The source universe Id which the request was sent in.
+    pub source_universe_id: u64,
+
+    /// When the friend request was sent.
+    pub sent_at: String,
+
+    /// The origin source type associated with the friend request.
+    /// ['Unknown' = 0, 'PlayerSearch' = 1, 'QrCode' = 2, 'InGame' = 3, 'UserProfile' = 4, 'QqContactImporter' = 5, 'WeChatContactImporter' = 6, 'ProfileShare' = 7, 'PhoneContactImporter' = 8, 'FriendRecommendations' = 9]
+    pub origin_source_type: String,
+
+    /// The contact name associated with the friend request.
+    pub contact_name: Option<String>,
+}
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct FriendsListResponse {
-    pub data: Vec<FriendsUserInformation>,
+    pub data: Vec<FriendUserInformationRaw>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -13,7 +91,7 @@ pub(super) struct FriendRequestsResponse {
     pub previous_page_cursor: Option<String>,
     pub next_page_cursor: Option<String>,
 
-    pub data: Vec<FriendRequestUserInformation>,
+    pub data: Vec<FriendRequestRaw>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,8 @@ mod chat;
 mod client;
 /// A module for endpoints prefixed with <https://economy.roblox.com/*>.
 pub mod economy;
+/// A module for endpoints prefixed with <https://friends.roblox.com/*>.
+pub mod friends;
 /// A module for endpoints prefixed with <https://groups.roblox.com/*>.
 pub mod groups;
 /// A module for endpoints prefixed with <https://presence.roblox.com/*>.
@@ -236,8 +238,6 @@ pub mod thumbnails;
 pub mod trades;
 /// A module for endpoints prefixed with <https://users.roblox.com/*>.
 pub mod users;
-/// A module for endpoints prefixed with <https://friends.roblox.com/*>.
-pub mod friends;
 /// A module related to validating requests.
 mod validation;
 // todo: figure out authtickets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ pub mod economy;
 /// A module for endpoints prefixed with <https://groups.roblox.com/*>.
 pub mod groups;
 /// A module for endpoints prefixed with <https://presence.roblox.com/*>.
-mod presence;
+pub mod presence;
 /// A module for endpoints prefixed with <https://privatemessages.roblox.com/*>.
 pub mod private_messages;
 /// A module for endpoints prefixed with <https://thumbnails.roblox.com/*>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@
 //!   - Fetch Friends List - [`Client::friends_list`]
 //!   - Accept Friend Request - [`Client::accept_friend_request`]
 //!   - Decline Friend Request - [`Client::decline_friend_request`]
+//!   - Send Friend Request - [`Client::send_friend_request`]
+//!   - Unfriend - [`Client::unfriend`]
 //! * UNDER CONSTRUCTION
 //!   - Upload Classic Clothing To Group - [`Client::upload_classic_clothing_to_group`]
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@
 //!   - User Search - [`Client::user_search`]
 //!   - Username User Search - [`Client::username_user_search`]
 //!   - Fetch User Details - [`Client::user_details`]
+//! * Friends API
+//!   - Fetch Count of Pending Friend Requests - [`Client::pending_friend_requests`]
+//!   - Fetch Friend Requests - [`Client::friend_requests`]
+//!   - Fetch Friends List - [`Client::friends_list`]
 //! * UNDER CONSTRUCTION
 //!   - Upload Classic Clothing To Group - [`Client::upload_classic_clothing_to_group`]
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@
 
 // Re-export reqwest so people can use the correct version.
 pub use reqwest;
+use serde::{Deserialize, Serialize};
 
 pub use bedev2::PurchaseNonTradableLimitedError;
 pub use client::{Client, ClientBuilder};
@@ -227,17 +228,16 @@ pub mod thumbnails;
 pub mod trades;
 /// A module for endpoints prefixed with <https://users.roblox.com/*>.
 pub mod users;
+/// A module for endpoints prefixed with <https://friends.roblox.com/*>.
+pub mod friends;
 /// A module related to validating requests.
 mod validation;
-
 // todo: figure out authtickets
 // todo: maybe respect cookies returned
 // todo: maybe add stronger types for stuff like cursors? stuff that can be returned basically and is unlikely to cbe created by the user.
 // todo: add doc example and example count somewhere
 // todo: the roblox api docs show the roblox error codes, maybe a custom sub error can be made
 // todo: add a "2 step not implemented for this endpoint" error
-
-use serde::{Deserialize, Serialize};
 
 // Used in request header keys.
 const XCSRF_HEADER: &str = "x-csrf-token";
@@ -322,7 +322,8 @@ pub enum RoboatError {
     #[error("Unidentified Status Code {0}")]
     UnidentifiedStatusCode(u16),
     /// Used when the response from an API endpoint is malformed.
-    #[error("Malformed Response. If this occurs often it may be a bug. Please report it to the issues page.")]
+    #[error("Malformed Response. If this occurs often it may be a bug. Please report it to the issues page."
+    )]
     MalformedResponse,
     /// Used when an endpoint rejects a request due to an invalid xcsrf.
     /// Mostly used internally invalid xcsrf is returned due to the fact that rust does not
@@ -336,11 +337,13 @@ pub enum RoboatError {
     /// Used when an endpoint returns a 403 status code, but not because of an invalid xcsrf.
     /// The string inside this error variant is a challenge id, which can be used to complete the challenge
     /// (which can be either a captcha or a two step verification code).
-    #[error("Challenge Required. A captcha or two step authentication must be completed using challenge id {0}.")]
+    #[error("Challenge Required. A captcha or two step authentication must be completed using challenge id {0}."
+    )]
     ChallengeRequired(String),
     /// Used when an endpoint returns a 403 status code, can be parsed into a roblox error,
     /// but the error message is incorrect or the challenge id is not returned. This also means that no xcsrf was returned.
-    #[error("Unknown Status Code 403 Format. If this occurs often it may be a bug. Please report it to the issues page.")]
+    #[error("Unknown Status Code 403 Format. If this occurs often it may be a bug. Please report it to the issues page."
+    )]
     UnknownStatus403Format,
     /// Custom Roblox errors sometimes thrown when the user calls [`Client::purchase_tradable_limited`].
     #[error("{0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,8 @@
 //!   - Fetch Count of Pending Friend Requests - [`Client::pending_friend_requests`]
 //!   - Fetch Friend Requests - [`Client::friend_requests`]
 //!   - Fetch Friends List - [`Client::friends_list`]
+//!   - Accept Friend Request - [`Client::accept_friend_request`]
+//!   - Decline Friend Request - [`Client::decline_friend_request`]
 //! * UNDER CONSTRUCTION
 //!   - Upload Classic Clothing To Group - [`Client::upload_classic_clothing_to_group`]
 //!

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -1,7 +1,36 @@
+use serde::{Deserialize, Serialize};
 use crate::{Client, RoboatError};
 
 const REGISTER_PRESENCE_API: &str = "https://presence.roblox.com/v1/presence/register-app-presence";
 
+/// Presence of user
+#[allow(missing_docs)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
+pub enum PresenceType {
+    #[default]
+    Offline,
+    Online,
+    InGame,
+    InStudio,
+    Invisible,
+}
+
+impl TryFrom<i32> for PresenceType {
+    type Error = RoboatError;
+
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(Self::Offline),
+            1 => Ok(Self::Online),
+            2 => Ok(Self::InGame),
+            3 => Ok(Self::InStudio),
+            4 => Ok(Self::Invisible),
+            _ => Err(RoboatError::MalformedResponse)
+        }
+    }
+}
+
+// TODO: add method for fetching users' presence
 impl Client {
     /// Registers presence on the website (makes you appear to be online). Endpoint called is
     /// <https://presence.roblox.com/v1/presence/register-app-presence>

--- a/src/presence/mod.rs
+++ b/src/presence/mod.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use crate::{Client, RoboatError};
+use serde::{Deserialize, Serialize};
 
 const REGISTER_PRESENCE_API: &str = "https://presence.roblox.com/v1/presence/register-app-presence";
 
@@ -25,7 +25,7 @@ impl TryFrom<i32> for PresenceType {
             2 => Ok(Self::InGame),
             3 => Ok(Self::InStudio),
             4 => Ok(Self::Invisible),
-            _ => Err(RoboatError::MalformedResponse)
+            _ => Err(RoboatError::MalformedResponse),
         }
     }
 }


### PR DESCRIPTION
Added Friends Api Endpoint
 - 3 methods: `friends_list`, `friend_requests`, `pending_friend_requests`
 - 2 examples: [friend_requests.rs](https://github.com/Mon4ik/roboat/blob/2c456d7538c4ba0cd3fc53ddd500c39cdf06068c/examples/friend_requests.rs) and [friends_list.rs](https://github.com/Mon4ik/roboat/blob/2c456d7538c4ba0cd3fc53ddd500c39cdf06068c/examples/friends_list.rs)

**In plans:** add methods for managing requests/friends, maybe add support for enum values (friend's `presenceType`, friend request's `originSourceType`)